### PR TITLE
Multiple-Master-Aware Optimizations

### DIFF
--- a/FixZeroHandles.glyphsFilter/Contents/Info.plist
+++ b/FixZeroHandles.glyphsFilter/Contents/Info.plist
@@ -19,15 +19,15 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>UpdateFeedURL</key>
 	<string>https://raw.githubusercontent.com/mekkablue/FixZeroHandles/master/FixZeroHandles.glyphsFilter/Contents/Info.plist</string>
 	<key>productPageURL</key>
 	<string>https://github.com/mekkablue/FixZeroHandles</string>
 	<key>productReleaseNotes</key>
-	<string>Turns curve segment with two consecutive zero handles into a straight line (thx @TrueTyper).</string>
+	<string>Curve to line optimization is now aware of other masters.</string>
 	<key>LSHasLocalizedDisplayName</key>
 	<false/>
 	<key>NSAppleScriptEnabled</key>

--- a/FixZeroHandles.glyphsFilter/Contents/Resources/FixZeroHandles.py
+++ b/FixZeroHandles.glyphsFilter/Contents/Resources/FixZeroHandles.py
@@ -74,7 +74,7 @@ class GlyphsFilterFixZeroHandles ( NSObject, GlyphsFilterProtocol ):
 		"""
 		This is the human-readable name as it appears in the menu.
 		"""
-		return "Fix Zero Handles MM"
+		return "Fix Zero Handles"
 	
 	def keyEquivalent( self ):
 		""" 


### PR DESCRIPTION
The curve-to-line-optimization (for two zero handles on one curve) that was added in the previous update checks now if the curve can be replaced by an equivalent line in every master, and only then actually turns it into a line in all masters, so the masters stay compatible. If the curve must stay a curve under these conditions, its zero handles are extended by ⅓ towards each end point. Pseudo lines that are constructed this way will interpolate nicer with a real curve in another master.
